### PR TITLE
Add dark mode overrides

### DIFF
--- a/neat.css
+++ b/neat.css
@@ -86,3 +86,23 @@ button {
         margin-right: 60px;
     }
 }
+
+/* Dark mode overrides */
+@media (prefers-color-scheme: dark) {
+    * {
+        color: white;
+    }
+
+    html {
+        border-color: white;
+    }
+
+    body {
+        background-color: #404040;
+    }
+
+    button, .button, .home {
+        background-color: white;
+        color: #404040;
+    }
+}


### PR DESCRIPTION
Added simple dark mode overrides for #5. Adds around 300 bytes. Browsers without support for `prefers-color-scheme` should simply show the light scheme instead.

This basically inverts the two colors: every instance of `#404040` is `white` in dark mode and vice-versa.