### PR TITLE
Fix default <input> color for dark theme

### DIFF
--- a/neat.css
+++ b/neat.css
@@ -101,7 +101,7 @@ button {
         background-color: #404040;
     }
 
-    button, .button, .home {
+    button, .button, .home, input {
         background-color: white;
         color: #404040;
     }

--- a/neat.html
+++ b/neat.html
@@ -131,6 +131,14 @@ curl -O https://neat.joeldare.com/neat.html</code></pre>
 
     <button class="center">Button</button>
 
+    <h3>Input</h3>
+
+    <p>The <em>input</em> tag is styled to support light and dark themes.</p>
+
+    <pre>&lt;input&gt;</pre>
+
+    <input class="center" value="My input here">
+
     <h3>No Header</h3>
 
     <p>Because of the complexity of the css and the distraction of navigation, there is no header and no navigation, other than the link back to the home page.</p>


### PR DESCRIPTION
I'm enjoying playing with `neatcss`, thanks @codazoda! Also, thanks @C0Nd3Mnd for adding the dark theme (#9)

This PR fixes a bug I discovered with the dark theme.

- In dark mode, the `<input>` tag has a white background and also ends up with `white` as foreground, so text is hidden.
- @codazoda I also added a section in the README so the `<input>` could be seen working in both light/dark themes. You may want to tweak or do something different documentation-wise.