### PR TITLE
Unify button styles

### DIFF
--- a/neat.css
+++ b/neat.css
@@ -30,7 +30,7 @@ pre {
     overflow: auto;
 }
 
-button {
+button, .button {
     display: inline-block;
     background-color: #404040;
     color: white;
@@ -41,18 +41,9 @@ button {
     border-radius: 5px;
     text-decoration: none;
     border: none;
+    line-height: normal;
 }
 
-.button {
-    display: inline-block;
-    background-color: #404040;
-    color: white;
-    text-align: center;
-    padding: 8px;
-    margin-right: 5px;
-    border-radius: 5px;
-    text-decoration: none;
-}
 
 .button:lastchild {
     margin-right: 0;


### PR DESCRIPTION
This merge request unifies the ruleset for both button types, effectively saving a few bytes. It also sets the `line-height` to `normal`, effectively making the buttons look identical.

Before (`<a>` tag button higher than the normal `<button>`):

![image](https://user-images.githubusercontent.com/47672946/108315308-82ab0080-71bb-11eb-84e2-7455326e58b9.png)

![image](https://user-images.githubusercontent.com/47672946/108315325-8b9bd200-71bb-11eb-9a6a-e2167e776daf.png)

After this change, the `<a>` button is the same height:

![image](https://user-images.githubusercontent.com/47672946/108315550-dc132f80-71bb-11eb-8270-5ffb092a70d3.png)

This is opinionated (applying the look of the `<button>` to `<a>`) and I could switch it around (making the other button higher instead of this one lower) if you'd like.