### PR TITLE
Change :lastchild to :last-child

### DIFF
--- a/neat.css
+++ b/neat.css
@@ -54,7 +54,7 @@ button {
     text-decoration: none;
 }
 
-.button:lastchild {
+button:last-child, .button:last-child {
     margin-right: 0;
 }
 


### PR DESCRIPTION
There's no `:lastchild` selector, it's instead called `:last-child` selector ([see MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/:last-child)). This PR changes the CSS so the `:last-child` selector is used and also applies the rules to the `.button` class as well (as opposed to just to the `button` tag).

![image](https://user-images.githubusercontent.com/47672946/108316388-234df000-71bd-11eb-8881-187db7a41442.png)

After this change, the rules apply as intended.