### PR TITLE
Apply the font-family to buttons and inputs as well

### DIFF
--- a/neat.css
+++ b/neat.css
@@ -1,13 +1,13 @@
 * {
     box-sizing: border-box;
     color: #404040;
+    font-family: sans-serif;
 }
 
 html {
     border-style: solid;
     border-width: 5px 0 0 0;
     border-color: #404040;
-    font-family: sans-serif;
 }
 
 body {

--- a/neat.css
+++ b/neat.css
@@ -1,13 +1,16 @@
 * {
     box-sizing: border-box;
     color: #404040;
-    font-family: sans-serif;
 }
 
 html {
     border-style: solid;
     border-width: 5px 0 0 0;
     border-color: #404040;
+}
+
+html, button, input {
+    font-family: sans-serif;
 }
 
 body {


### PR DESCRIPTION
This PR applies the `font-family` to the `*` ruleset instead of the `html` ruleset. This has the advantage of styling the button as well. At first I didn't notice any difference as my browser uses `Arial` as the default font for buttons, and it also happens to be the default font for `sans-serif`.

On closer inspection, you can see that the font for the button is overridden by the user agent stylesheet:

![image](https://user-images.githubusercontent.com/47672946/108316966-e9311e00-71bd-11eb-94a8-881924708965.png)

Changing the font to `monospace` (just as an example to make it more obvious) makes the page look like this then:

![image](https://user-images.githubusercontent.com/47672946/108317062-0ebe2780-71be-11eb-8dfd-55c711af753b.png)

If the `font-family` rule is applied to `*` instead, the `<button>` respects the rule as it should:

![image](https://user-images.githubusercontent.com/47672946/108317159-2a293280-71be-11eb-9b2d-b61689102232.png)

And with `sans-serif`:

![image](https://user-images.githubusercontent.com/47672946/108317246-44fba700-71be-11eb-822e-6ec094c244b8.png)

Any rules in the `*` ruleset override the user agent ruleset for the `button`:

![image](https://user-images.githubusercontent.com/47672946/108317302-5cd32b00-71be-11eb-87b2-802243618200.png)
