### PR TITLE
added cursor:pointer on button styles

### DIFF
--- a/neat.css
+++ b/neat.css
@@ -49,6 +49,7 @@ button, .button {
     text-decoration: none;
     border: none;
     line-height: normal;
+    cursor: pointer;
 }
 
 


### PR DESCRIPTION
The pointer style wasn't showing on button elements (as tested in Firefox), this fork adds cursor:pointer to the `button, .button` styles.

First fork/pull request, hope this was okay.